### PR TITLE
Add CODEOWNERS and enable Dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These code owners will be automatically requested
+# for review on every Pull Request in this repository.
+# Please keep this file up to date with staffing changes.
+*       @daniftodi


### PR DESCRIPTION
Adds a `.github/CODEOWNERS` so PRs in this repo route to a person, and turns on Dependabot.

**Why:** the `Dependabot Monitor` workflow in `extole/tech` pings `@channel` in
`#ai-library-upgrades` because most repos have nobody specific to notify. Before this batch, only
10 of the 54 repos in `bin/lib/repo-settings.json` had a CODEOWNERS file.

**How the owners were chosen:** top 3 authors by all-time commit count, restricted to people who
are currently in the `extole` GitHub org and have write access to this repo. Both filters matter —
19 of the 31 historical contributors across these repos have left, and a CODEOWNERS entry for
someone without write access is silently ignored by GitHub.

Commit counts for the selected owners in this repo: daniftodi 2.

**Dependabot:** no `dependabot.yml` — no supported manifests found in this repo.
Alerts and security updates are still being enabled on the repo settings.

@daniftodi — if these owners are wrong, say so here and they can be changed before merge.
